### PR TITLE
Added zentity to the list of API extension plugins

### DIFF
--- a/docs/plugins/api.asciidoc
+++ b/docs/plugins/api.asciidoc
@@ -19,6 +19,9 @@ A number of plugins have been contributed by our community:
 
 * https://github.com/YannBrrd/elasticsearch-entity-resolution[Entity Resolution Plugin]:
   Uses http://github.com/larsga/Duke[Duke] for duplication detection (by Yann Barraud)
+  
+* https://github.com/zentity-io/zentity[Entity Resolution Plugin] (https://zentity.io[zentity]):
+  Real-time entity resolution with pure Elasticsearch (by Dave Moore)
 
 * https://github.com/NLPchina/elasticsearch-sql/[SQL language Plugin]:
   Allows Elasticsearch to be queried with SQL (by nlpcn)


### PR DESCRIPTION
Added a plugin ([zentity](https://github.com/zentity-io/zentity)) to the list of API extension plugins in the docs.